### PR TITLE
Redirect MSAL Python overview page

### DIFF
--- a/.openpublishing.redirection.msal-python-conceptual.json
+++ b/.openpublishing.redirection.msal-python-conceptual.json
@@ -1,8 +1,8 @@
 {
   "redirections": [
     {
-      "source_path_from_root": "msal-python-conceptual/overview-msal",
-      "redirect_url": "msal-python-conceptual/index.md",
+      "source_path_from_root": "/msal-python-conceptual/overview-msal",
+      "redirect_url": "/msal-python-conceptual/index",
       "redirect_document_id": true
     }
   ]


### PR DESCRIPTION
@OwenRichards1 this fixes #https://github.com/MicrosoftDocs/azure-docs/issues/111713 and any other docs pointing to the old link. 