### PR TITLE
Adding articles from identity platform, modified TOC

### DIFF
--- a/msal-python-conceptual/TOC.yml
+++ b/msal-python-conceptual/TOC.yml
@@ -13,19 +13,19 @@
   - name: Using MSAL Python with Web Account Manager
     href: advanced/wam.md
   - name: Migrate to MSAL Python
-    href: /azure/active-directory/develop/migrate-python-adal-msal
+    href: migrate-python-adal-msal.md
   - name: Logging
-    href: /azure/active-directory/develop/msal-logging-python
+    href: msal-logging-python.md
   - name: Handle errors and exceptions
-    href: /azure/active-directory/develop/msal-error-handling-python
+    href: msal-error-handling-python.md
   - name: Conditional access
     href: advanced/conditional-access.md
   - name: Token cache serialization
-    href: /azure/active-directory/develop/msal-python-token-cache-serialization
+    href: msal-python-token-cache-serialization.md
   - name: Developing an Azure AD B2C app with MSAL Python
     href: advanced/aad-b2c.md
   - name: Active Directory Federation Services (ADFS) Support
-    href: /azure/active-directory/develop/msal-python-adfs-support
+    href: msal-python-adfs-support.md
   - name: National clouds
     href: /azure/active-directory/develop/msal-national-cloud?tabs=python
   - name: Username and password authentication

--- a/msal-python-conceptual/advanced/migrate-python-adal-msal.md
+++ b/msal-python-conceptual/advanced/migrate-python-adal-msal.md
@@ -1,0 +1,107 @@
+---
+title: Python ADAL to MSAL migration guide
+description: Learn how to migrate your Azure Active Directory Authentication Library (ADAL) Python app to the Microsoft Authentication Library (MSAL) for Python.
+---
+
+# ADAL to MSAL migration guide for Python
+
+This article highlights changes you need to make to migrate an app that uses the Azure Active Directory Authentication Library (ADAL) to use the Microsoft Authentication Library (MSAL).
+
+You can learn more about MSAL and get started with an [overview of the Microsoft Authentication Library](msal-overview.md).
+
+## Difference highlights
+
+ADAL works with the Azure Active Directory (Azure AD) v1.0 endpoint. The Microsoft Authentication Library (MSAL) works with the Microsoft identity platform--formerly known as the Azure Active Directory v2.0 endpoint. The Microsoft identity platform differs from Azure AD v1.0 in that it:
+
+Supports:
+
+- Work and school accounts (Azure AD provisioned accounts)
+- Personal accounts (such as Outlook.com or Hotmail.com)
+- Your customers who bring their own email or social identity (such as LinkedIn, Facebook, Google) via the Azure AD B2C offering
+
+- Is standards compatible with:
+  - OAuth v2.0
+  - OpenID Connect (OIDC)
+
+For more information about MSAL, see [MSAL overview](./msal-overview.md).
+
+### Scopes not resources
+
+ADAL Python acquires tokens for resources, but MSAL Python acquires tokens for scopes. The API surface in MSAL Python doesn't have resource parameter anymore. You would need to provide scopes as a list of strings that declare the desired permissions and resources that are requested. To see some example of scopes, see [Microsoft Graph's scopes](/graph/permissions-reference).
+
+You can add the `/.default` scope suffix to the resource to help migrate your apps from the v1.0 endpoint (ADAL) to the Microsoft identity platform (MSAL). For example, for the resource value of `https://graph.microsoft.com`, the equivalent scope value is `https://graph.microsoft.com/.default`. If the resource isn't in the URL form, but a resource ID of the form `XXXXXXXX-XXXX-XXXX-XXXXXXXXXXXX`, you can still use the scope value as `XXXXXXXX-XXXX-XXXX-XXXXXXXXXXXX/.default`.
+
+For more details about the different types of scopes, refer to [Permissions and consent in the Microsoft identity platform](/azure/active-directory/develop/permissions-consent-overview.md) and the [Scopes for a Web API accepting v1.0 tokens](/azure/active-directory/develop/msal-v1-app-scopes.md) articles.
+
+### Error handling
+
+ADAL for Python uses the exception `AdalError` to indicate that there's been a problem. MSAL for Python typically uses error codes, instead. For more information, see [MSAL for Python error handling](msal-error-handling-python.md).
+
+### API changes
+
+The following table lists an API in ADAL for Python, and the one to use in its place in MSAL for Python:
+
+| ADAL for Python API | MSAL for Python API |
+| ------------------- | ------------------- |
+| [AuthenticationContext](https://adal-python.readthedocs.io/en/latest/#adal.AuthenticationContext)                                                                                                                                                                                                                       | [PublicClientApplication](https://msal-python.readthedocs.io/en/latest/#msal.PublicClientApplication.__init__) or [ConfidentialClientApplication](https://msal-python.readthedocs.io/en/latest/#msal.ConfidentialClientApplication.__init__)                                                                                                                                                                                                                                    |
+| N/A                                                                                                                                                                                                                                                                                                                     | [PublicClientApplication.acquire_token_interactive()](https://msal-python.readthedocs.io/en/latest/#msal.PublicClientApplication.acquire_token_interactive)                                                                                                                                                                                                                                                                                                                     |
+| N/A                                                                                                                                                                                                                                                                                                                     | [ConfidentialClientApplication.initiate_auth_code_flow()](https://msal-python.readthedocs.io/en/latest/#msal.ConfidentialClientApplication.initiate_auth_code_flow)                                                                                                                                                                                                                                                                                                             |
+| [acquire_token_with_authorization_code()](https://adal-python.readthedocs.io/en/latest/#adal.AuthenticationContext.acquire_token_with_authorization_code)                                                                                                                                                               | [ConfidentialClientApplication.acquire_token_by_auth_code_flow()](https://msal-python.readthedocs.io/en/latest/#msal.ConfidentialClientApplication.acquire_token_by_auth_code_flow)                                                                                                                                                                                                                                                                                             |
+| [acquire_token()](https://adal-python.readthedocs.io/en/latest/#adal.AuthenticationContext.acquire_token)                                                                                                                                                                                                               | [PublicClientApplication.acquire_token_silent()](https://msal-python.readthedocs.io/en/latest/#msal.PublicClientApplication.acquire_token_silent) or [ConfidentialClientApplication.acquire_token_silent()](https://msal-python.readthedocs.io/en/latest/#msal.ConfidentialClientApplication.acquire_token_silent)                                                                                                                                                              |
+| [acquire_token_with_refresh_token()](https://adal-python.readthedocs.io/en/latest/#adal.AuthenticationContext.acquire_token_with_refresh_token)                                                                                                                                                                         | These two helpers are intended to be used during [migration](#migrate-existing-refresh-tokens-for-msal-python) only: [PublicClientApplication.acquire_token_by_refresh_token()](https://msal-python.readthedocs.io/en/latest/#msal.PublicClientApplication.acquire_token_by_refresh_token) or [ConfidentialClientApplication.acquire_token_by_refresh_token()](https://msal-python.readthedocs.io/en/latest/#msal.ConfidentialClientApplication.acquire_token_by_refresh_token) |
+| [acquire_user_code()](https://adal-python.readthedocs.io/en/latest/#adal.AuthenticationContext.acquire_user_code)                                                                                                                                                                                                       | [initiate_device_flow()](https://msal-python.readthedocs.io/en/latest/#msal.PublicClientApplication.initiate_device_flow)                                                                                                                                                                                                                                                                                                                                                       |
+| [acquire_token_with_device_code()](https://adal-python.readthedocs.io/en/latest/#adal.AuthenticationContext.acquire_token_with_device_code) and [cancel_request_to_get_token_with_device_code()](https://adal-python.readthedocs.io/en/latest/#adal.AuthenticationContext.cancel_request_to_get_token_with_device_code) | [acquire_token_by_device_flow()](https://msal-python.readthedocs.io/en/latest/#msal.PublicClientApplication.acquire_token_by_device_flow)                                                                                                                                                                                                                                                                                                                                       |
+| [acquire_token_with_username_password()](https://adal-python.readthedocs.io/en/latest/#adal.AuthenticationContext.acquire_token_with_username_password)                                                                                                                                                                 | [acquire_token_by_username_password()](https://msal-python.readthedocs.io/en/latest/#msal.PublicClientApplication.acquire_token_by_username_password)                                                                                                                                                                                                                                                                                                                           |
+| [acquire_token_with_client_credentials()](https://adal-python.readthedocs.io/en/latest/#adal.AuthenticationContext.acquire_token_with_client_credentials) and [acquire_token_with_client_certificate()](https://adal-python.readthedocs.io/en/latest/#adal.AuthenticationContext.acquire_token_with_client_certificate) | [acquire_token_for_client()](https://msal-python.readthedocs.io/en/latest/#msal.ConfidentialClientApplication.acquire_token_for_client)                                                                                                                                                                                                                                                                                                                                         |
+| N/A                                                                                                                                                                                                                                                                                                                     | [acquire_token_on_behalf_of()](https://msal-python.readthedocs.io/en/latest/#msal.ConfidentialClientApplication.acquire_token_on_behalf_of)                                                                                                                                                                                                                                                                                                                                     |
+| [TokenCache()](https://adal-python.readthedocs.io/en/latest/#adal.TokenCache)                                                                                                                                                                                                                                           | [SerializableTokenCache()](https://msal-python.readthedocs.io/en/latest/#msal.SerializableTokenCache)                                                                                                                                                                                                                                                                                                                                                                           |
+| N/A                                                                                                                                                                                                                                                                                                                     | Cache with persistence, available from [MSAL Extensions](https://github.com/marstr/original-microsoft-authentication-extensions-for-python)                                                                                                                                                                                                                                                                                                                                     |
+
+## Migrate existing refresh tokens for MSAL Python
+
+MSAL abstracts the concept of refresh tokens. MSAL Python provides an in-memory token cache by default so that you don't need to store, lookup, or update refresh tokens. Users will also see fewer sign-in prompts because refresh tokens can usually be updated without user intervention. For more information about the token cache, see [Custom token cache serialization in MSAL for Python](msal-python-token-cache-serialization.md).
+
+The following code will help you migrate your refresh tokens managed by another OAuth2 library (including but not limited to ADAL Python) to be managed by MSAL for Python. One reason for migrating those refresh tokens is to prevent existing users from needing to sign in again when you migrate your app to MSAL for Python.
+
+The method for migrating a refresh token is to use MSAL for Python to acquire a new access token using the previous refresh token. When the new refresh token is returned, MSAL for Python will store it in the cache.
+Since MSAL Python 1.3.0, we provide an API inside MSAL for this purpose.
+Please refer to the following code snippet, quoted from
+[a completed sample of migrating refresh tokens with MSAL Python](https://github.com/AzureAD/microsoft-authentication-library-for-python/blob/1.3.0/sample/migrate_rt.py#L28-L67)
+
+```python
+import msal
+def get_preexisting_rt_and_their_scopes_from_elsewhere():
+    # Maybe you have an ADAL-powered app like this
+    #   https://github.com/AzureAD/azure-activedirectory-library-for-python/blob/1.2.3/sample/device_code_sample.py#L72
+    # which uses a resource rather than a scope,
+    # you need to convert your v1 resource into v2 scopes
+    # See https://learn.microsoft.com/azure/active-directory/develop/migrate-python-adal-msal#scopes-not-resources
+    # You may be able to append "/.default" to your v1 resource to form a scope
+    # See https://learn.microsoft.com/azure/active-directory/develop/v2-permissions-and-consent#the-default-scope
+
+    # Or maybe you have an app already talking to the Microsoft identity platform,
+    # powered by some 3rd-party auth library, and persist its tokens somehow.
+
+    # Either way, you need to extract RTs from there, and return them like this.
+    return [
+        ("old_rt_1", ["scope1", "scope2"]),
+        ("old_rt_2", ["scope3", "scope4"]),
+        ]
+
+
+# We will migrate all the old RTs into a new app powered by MSAL
+app = msal.PublicClientApplication(
+    "client_id", authority="...",
+    # token_cache=...  # Default cache is in memory only.
+                       # You can learn how to use SerializableTokenCache from
+                       # https://msal-python.readthedocs.io/en/latest/#msal.SerializableTokenCache
+    )
+
+# We choose a migration strategy of migrating all RTs in one loop
+for old_rt, scopes in get_preexisting_rt_and_their_scopes_from_elsewhere():
+    result = app.acquire_token_by_refresh_token(old_rt, scopes)
+    if "error" in result:
+        print("Discarding unsuccessful RT. Error: ", json.dumps(result, indent=2))
+
+print("Migration completed")
+```

--- a/msal-python-conceptual/advanced/msal-error-handling-python.md
+++ b/msal-python-conceptual/advanced/msal-error-handling-python.md
@@ -1,0 +1,77 @@
+---
+title: Handle errors and exceptions in MSAL for Python
+description: Learn how to handle errors and exceptions, Conditional Access claims challenges, and retries in MSAL for Python applications.
+---
+# Handle errors and exceptions in MSAL for Python
+
+[!INCLUDE [Active directory error handling introduction](/azure/active-directory/develop/includes/error-handling-and-tips/error-handling-introduction.md)]
+
+## Error handling in MSAL for Python
+
+In MSAL for Python, most errors are conveyed as a return value from the API call. The error is represented as a dictionary containing the JSON response from the Microsoft identity platform.
+
+* A successful response contains the `"access_token"` key. The format of the response is defined by the OAuth2 protocol. For more information, see [5.1 Successful Response](https://tools.ietf.org/html/rfc6749#section-5.1)
+* An error response contains `"error"` and usually `"error_description"`. The format of the response is defined by the OAuth2 protocol. For more information, see [5.2 Error Response](https://tools.ietf.org/html/rfc6749#section-5.2)
+
+When an error is returned, the `"error"` key contains a machine-readable code. If the `"error"` is, for example, an `"interaction_required"`, you may prompt the user to provide additional information to complete the authentication process. If the `"error"` is `"invalid_grant"`, you may prompt the user to reenter their credentials. The following snippet is an example of error handling in MSAL for Python.
+
+```python
+
+from msal import ConfidentialClientApplication
+
+authority_url = "https://login.microsoftonline.com/your_tenant_id"
+client_id = "your_client_id"
+client_secret = "your_client_secret"
+scopes = ["https://graph.microsoft.com/.default"]
+
+app = ConfidentialClientApplication(client_id, authority=authority_url, client_credential=client_secret)
+
+result = app.acquire_token_silent(scopes=scopes, account=None)
+
+if not result:
+    result = app.acquire_token_silent(scopes=scopes)
+
+if "access_token" in result:
+    print("Access token: %s" % result["access_token"])
+else:
+    print("Error: %s" % result.get("error"))
+
+```
+
+When an error is returned, the `"error_description"` key also contains a human-readable message, and there is typically also an `"error_code"` key which contains a machine-readable Microsoft identity platform error code. For more information about the various Microsoft identity platform error codes, see [Authentication and authorization error codes](/azure/active-directory/develop/reference-error-codes.md).
+
+In MSAL for Python, exceptions are rare because most errors are handled by returning an error value. The `ValueError` exception is only thrown when there's an issue with how you're attempting to use the library, such as when API parameter(s) are malformed.
+
+[!INCLUDE [Active directory error handling claims challenges](/azure/active-directory/develop/includes/error-handling-and-tips/error-handling-claims-challenges.md)]
+
+
+## Retrying after errors and exceptions
+
+MSAL makes HTTP calls to the Azure AD service, and occasionally failures can occur.
+For example the network can go down or the server is overloaded.
+
+MSAL Python 1.11+ automatically performs one retry attempt for you.
+You may customize this behavior by following
+[this instruction](https://msal-python.readthedocs.io/en/latest/#msal.ConfidentialClientApplication.params.http_client).
+
+### HTTP 429
+
+When the Service Token Server (STS) is overloaded with too many requests,
+it returns HTTP error 429 with a hint about how long until you can try again in the `Retry-After` response field.
+
+Your app was expected to throttle the subsequent requests, and only retry after the specified period.
+That was not an easy task.
+
+MSAL Python 1.16+ made it easy for you, in that your app could blindly retry in any given time
+(say, whenever the end user clicks the sign-in button again),
+MSAL Python 1.16+ would automatically throttle those retry attempts by returning same error response from an HTTP cache,
+and only sending out a real HTTP call when that call is attempted after the specified period.
+
+By default, this throttle mechanism works by saving throttle information into a built-in in-memory HTTP cache.
+You may provide your own `dict`-like object as the HTTP cache, which you can control how to persist its content.
+See [MSAL Python's API document](https://msal-python.readthedocs.io/en/latest/#msal.PublicClientApplication.params.http_cache)
+for more details.
+
+## Next steps
+
+Consider enabling [Logging in MSAL for Python](msal-logging-python.md) to help you diagnose and debug issues.

--- a/msal-python-conceptual/advanced/msal-logging-python.md
+++ b/msal-python-conceptual/advanced/msal-logging-python.md
@@ -1,0 +1,65 @@
+---
+title: Logging errors and exceptions in MSAL for Python
+description: Learn how to log errors and exceptions in MSAL for Python
+---
+
+# Logging in MSAL for Python
+
+[!INCLUDE [MSAL logging introduction](/azure/active-directory/develop/includes/error-handling-and-tips/error-logging-introduction.md)]
+
+## MSAL for Python logging
+
+Logging in MSAL for Python leverages the [logging module in the Python standard library](https://docs.python.org/3/library/logging.html). You can configure MSAL logging as follows (and see it in action in the [username_password_sample](https://github.com/AzureAD/microsoft-authentication-library-for-python/blob/1.0.0/sample/username_password_sample.py#L31L32)):
+
+### Enable debug logging for all modules
+
+By default, the logging in any Python script is turned off. If you want to enable verbose logging for **all** Python modules in your script, use `logging.basicConfig` with a level of `logging.DEBUG`:
+
+```python
+import logging
+
+logging.basicConfig(level=logging.DEBUG)
+```
+
+This will print all log messages given to the logging module to the standard output.
+
+### Configure MSAL logging level
+
+You can configure the logging level of the MSAL for Python log provider by using the `logging.getLogger()` method with the logger name `"msal"`:
+
+```python
+import logging
+
+logging.getLogger("msal").setLevel(logging.WARN)
+```
+
+### Configure MSAL logging with Azure App Insights
+
+Python logs are given to a log handler, which by default is the `StreamHandler`. To send MSAL logs to an Application Insights with an Instrumentation Key, use the `AzureLogHandler` provided by the `opencensus-ext-azure` library.
+
+To install, `opencensus-ext-azure` add the `opencensus-ext-azure` package from PyPI to your dependencies or pip install:
+
+```console
+pip install opencensus-ext-azure
+```
+
+Then change the default handler of the `"msal"` log provider to an instance of `AzureLogHandler` with an instrumentation key set in the `APP_INSIGHTS_KEY` environment variable:
+
+```python
+import logging
+import os
+
+from opencensus.ext.azure.log_exporter import AzureLogHandler
+
+APP_INSIGHTS_KEY = os.getenv('APP_INSIGHTS_KEY')
+
+logging.getLogger("msal").addHandler(AzureLogHandler(connection_string='InstrumentationKey={0}'.format(APP_INSIGHTS_KEY)))
+```
+
+### Personal and organizational data in Python
+
+MSAL for Python does not log personal data or organizational data. There is no property to turn personal or organization data logging on or off.
+
+You can use standard Python logging to log whatever you want, but you are responsible for safely handling sensitive data and following regulatory requirements.
+
+For more information about logging in Python, please refer to Python's  [Logging: how-to](https://docs.python.org/3/howto/logging.html#logging-basic-tutorial).

--- a/msal-python-conceptual/advanced/msal-python-adfs-support.md
+++ b/msal-python-conceptual/advanced/msal-python-adfs-support.md
@@ -1,0 +1,54 @@
+---
+title: Azure AD FS support (MSAL Python)
+description: Learn about Active Directory Federation Services (AD FS) support in the Microsoft Authentication Library for Python
+services: active-directory
+author: Dickson-Mwendia
+manager: CelesteDG
+
+ms.service: active-directory
+ms.subservice: develop
+ms.topic: conceptual
+ms.workload: identity
+ms.date: 11/23/2019
+ms.author: dmwendia
+ms.reviewer: celested, nacanuma
+ms.custom: aaddev, devx-track-python, has-adal-ref
+#Customer intent: As an application developer, I want to learn about AD FS support in MSAL for Python so I can decide if this platform meets my application development needs and requirements.
+---
+
+# Active Directory Federation Services support in MSAL for Python
+
+Active Directory Federation Services (AD FS) in Windows Server enables you to add OpenID Connect and OAuth 2.0 based authentication and authorization to your apps by using the Microsoft Authentication Library (MSAL) for Python. Using the MSAL for Python library, your app can authenticate users directly against AD FS. For more information about scenarios, see [AD FS Scenarios for Developers](/windows-server/identity/ad-fs/ad-fs-development).
+
+There are usually two ways of authenticating against AD FS:
+
+- MSAL Python talks to Azure Active Directory, which itself is federated with other identity providers. The federation happens through AD FS. MSAL Python connects to Azure AD, which signs in users that are managed in Azure AD (managed users) or users managed by another identity provider such as AD FS (federated users). MSAL Python doesn't  know that a user is federated. It simply talks to Azure AD. The [authority](msal-client-application-configuration.md#authority) you use in this case is the usual authority (authority host name + tenant, common, or organizations).
+- MSAL Python talks directly to an AD FS authority. This is only supported by AD FS 2019 and later.
+
+## Connect to Active Directory federated with AD FS
+
+### Acquire a token interactively for a federated user
+
+The following applies whether you connect directly to Active Directory Federation Services (AD FS) or through Active Directory.
+
+When you call `acquire_token_by_authorization_code` or `acquire_token_by_device_flow`, the user experience is typically as follows:
+
+1. The user enters their account ID.
+2. Azure AD displays briefly the message "Taking you to your organization's page" and the user is redirected to the sign-in page of the identity provider. The sign-in page is usually customized with the logo of the organization.
+
+The supported AD FS versions in this federated scenario are:
+- Active Directory Federation Services FS v2
+- Active Directory Federation Services v3 (Windows Server 2012 R2)
+- Active Directory Federation Services v4 (AD FS 2016)
+
+### Acquire a token via username and password
+
+The following applies whether you connect directly to Active Directory Federation Services (AD FS) or through Active Directory.
+
+When you acquire a token using `acquire_token_by_username_password`, MSAL Python gets the identity provider to contact based on the username. MSAL Python gets a [SAML 1.1 token](reference-saml-tokens.md) from the identity provider, which it then provides to Azure AD which returns the JSON Web Token (JWT).
+
+## Connecting directly to AD FS
+
+When you connect directory to AD FS, the authority you'll want to use to build your application will be something like `https://somesite.contoso.com/adfs/`
+
+MSAL Python supports ADFS 2019, but does not support a direct connection to ADFS 2016 or ADFS v2. Once you have upgraded your on-premises system to ADFS 2019, you can use MSAL Python.

--- a/msal-python-conceptual/advanced/msal-python-token-cache-serialization.md
+++ b/msal-python-conceptual/advanced/msal-python-token-cache-serialization.md
@@ -1,0 +1,24 @@
+---
+title: Custom token cache serialization (MSAL Python)
+description: Learn how to serialize token cache using MSAL for Python
+---
+
+# Custom token cache serialization in MSAL for Python
+
+In Microsoft Authentication Library (MSAL) for Python, an in-memory token cache that persists for the duration of the app session, is provided by default when you create an instance of [ClientApplication](/python/api/msal/msal.application.confidentialclientapplication).
+
+Serialization of the token cache, so that different sessions of your app can access it, isn't provided "out of the box." MSAL for Python can be used in app types that don't have access to the file system--such as Web apps. To have a persistent token cache in an app that uses MSAL for Python, you must provide custom token cache serialization.
+
+The strategies for serializing the token cache differ depending on whether you're writing a public client application (Desktop), or a confidential client application (web app, web API, or daemon app).
+
+## Token cache for a public client application
+
+Public client applications run on a user's device and manage tokens for a single user. In this case, you could serialize the entire cache into a file. Remember to provide file locking if your app, or another app, can access the cache concurrently. For a simple example of how to serialize a token cache to a file without locking, see the example in the [SerializableTokenCache](/python/api/msal/msal.token_cache.serializabletokencache) class reference documentation.
+
+## Token cache for a Web app (confidential client application)
+
+For web apps or web APIs, you might use the session, or a Redis cache, or a database to store the token cache. There should be one token cache per user (per account) so ensure that you serialize the token cache per account.
+
+## Next steps
+
+See [ms-identity-python-webapp](https://github.com/Azure-Samples/ms-identity-python-webapp/blob/0.3.0/app.py#L66-L74) for an example of how to use the token cache for a Windows or Linux Web app or web API. The example is for a web app that calls the Microsoft Graph API.


### PR DESCRIPTION
Added the following markdown files from the identity platform

- migrate-python-adal-msal.md
- msal-error-handling-python.md
- msal-logging-python.md
- msal-python-adfs-support.md
- msal-python-token-cache-serialization.md

Modifying the TOC to link to these articles, not identity platform