### PR TITLE
B2C end of sale updates

### DIFF
--- a/msal-python-conceptual/advanced/aad-b2c.md
+++ b/msal-python-conceptual/advanced/aad-b2c.md
@@ -15,8 +15,10 @@ ms.reviewer: shermanouko, rayluo
 
 # Use MSAL Python to work with Azure AD B2C
 
-
 You can use MSAL Python to sign-in users with social identities, acquire tokens, and customize the sign-in experience by using [Azure AD B2C](https://aka.ms/aadb2c).
+
+> [!IMPORTANT]
+> Effective May 1, 2025, Azure AD B2C will no longer be available to purchase for new customers. To learn more, please see [Is Azure AD B2C still available to purchase?](/azure/active-directory-b2c/faq?tabs=app-reg-ga#azure-ad-b2c-end-of-sale) in our FAQ.
 
 Azure AD B2C is built around the notion of [User Flows](/azure/active-directory-b2c/active-directory-b2c-reference-policies) (formerly known as policies). In MSAL Python, specifying a user flow translates to providing an authority.
 

--- a/msal-python-conceptual/index.md
+++ b/msal-python-conceptual/index.md
@@ -15,7 +15,7 @@ ms.reviewer: dmwendia, rayluo
 
 # Microsoft Authentication Library (MSAL) for Python
 
-The Microsoft Authentication Library (MSAL) for Python library enables you to sign in users or apps with Microsoft identities ([Microsoft Entra ID](https://azure.microsoft.com/services/active-directory/), [Microsoft Accounts](https://account.microsoft.com), and [Azure AD B2C](https://azure.microsoft.com/services/active-directory-b2c/) accounts). Using MSAL Python, you can acquire tokens from Microsoft Entra ID to call protected web APIs such as [Microsoft Graph](https://graph.microsoft.io/), other Microsoft APIs, or your own APIs.
+The Microsoft Authentication Library (MSAL) for Python library enables you to sign in users or apps with Microsoft identities ([Microsoft Entra ID](https://azure.microsoft.com/services/active-directory/), [Microsoft Accounts](https://account.microsoft.com), and [Microsoft Entra ID](https://www.microsoft.com/security/business/identity-access/microsoft-entra-id) accounts). Using MSAL Python, you can acquire tokens from Microsoft Entra ID to call protected web APIs such as [Microsoft Graph](https://graph.microsoft.io/), other Microsoft APIs, or your own APIs.
 
 ## Prerequisites
 


### PR DESCRIPTION
Effective May 1, 2025, Azure AD B2C will no longer be available to purchase for new customers.
I opened this PR to add this information to the related docs.