### PR TITLE
Fix linkchecker by remapping root-relative links to learn.microsoft.com

### DIFF
--- a/.github/workflows/linkvalidator.yml
+++ b/.github/workflows/linkvalidator.yml
@@ -22,7 +22,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
         with:
-          args: --accept=200,429,403,502,503 --verbose --no-progress './**/*.md'
+          args: --accept=200,429,403,502,503 --verbose --no-progress --remap '/(.+) https://learn.microsoft.com/$1' './**/*.md'
           fail: true
 
       - name: Create Issue From File

--- a/.github/workflows/linkvalidator.yml
+++ b/.github/workflows/linkvalidator.yml
@@ -22,7 +22,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
         with:
-          args: --accept=200,429,403,502,503 --verbose --no-progress --remap '/(.+) https://learn.microsoft.com/$1' './**/*.md'
+          args: --accept=200,429,403,502,503 --verbose --no-progress --remap '^/(.+) https://learn.microsoft.com/$1' './**/*.md'
           fail: true
 
       - name: Create Issue From File

--- a/.github/workflows/linkvalidator.yml
+++ b/.github/workflows/linkvalidator.yml
@@ -16,13 +16,19 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Resolve root-relative links for checking
+        run: |
+          # Convert root-relative markdown links like [text](/path) to [text](https://learn.microsoft.com/path)
+          # so lychee can validate them. This only modifies the CI checkout copy.
+          find . -name '*.md' -exec sed -i -E 's|\]\(/|\](https://learn.microsoft.com/|g' {} +
+
       - name: Link Checker
         id: lychee
         uses: lycheeverse/lychee-action@master
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
         with:
-          args: --accept=200,429,403,502,503 --verbose --no-progress --remap '^/(.+) https://learn.microsoft.com/$1' './**/*.md'
+          args: --accept=200,429,403,502,503 --verbose --no-progress './**/*.md'
           fail: true
 
       - name: Create Issue From File

--- a/msal-python-conceptual/advanced/migrate.md
+++ b/msal-python-conceptual/advanced/migrate.md
@@ -25,7 +25,7 @@ and then when a new RT comes back, MSAL will store it in the usual way.
 As this method is intended for scenarios that are not typical, it is NOT readily accessible with the official API surface.
 You will have to call it via an internal helper `app.client`,
 and its naming convention is also slightly different than those other
-[official APIs]().
+[official APIs](../getting-started/acquiring-tokens.md).
 
 ```python
 from msal import PublicClientApplication


### PR DESCRIPTION
Add --remap flag to lychee args so root-relative links (e.g. /entra/...) are rewritten to https://learn.microsoft.com/... and validated against the live site instead of failing as unresolvable local paths.